### PR TITLE
feat: add Kupo

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
         max-size: "200k"
         max-file: "10"
     profiles:
+      - kupmios
       - node
       - node-api
       - ogmios
@@ -94,6 +95,43 @@ services:
       - ${BURSA_METRICS_LISTEN_PORT:-8081}:8081
     profiles:
       - bursa
+  
+  kupo:
+    container_name: kupo
+    image: cardanosolutions/kupo:${KUPO_VERSION:-v2.9.0}
+    environment:
+      - NETWORK=${CARDANO_NETWORK:-mainnet}
+      - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
+    depends_on:
+      cardano-node:
+        condition: service_healthy
+    volumes:
+      - node-ipc:/ipc
+      - kupo-db:/db
+      - node-config:/config
+    restart: on-failure
+    command:
+      - --node-socket
+      - /ipc/node.socket
+      - --host
+      - 0.0.0.0
+      - --port
+      - '1442'
+      - --log-level
+      - Info
+      - --node-config
+      - /config/${NETWORK:-mainnet}/config.json
+      - --match
+      - '*'
+      - --defer-db-indexes
+      - --since
+      - origin
+      - --workdir
+      - '/db'
+    ports:
+      - "1442:1442"
+    profiles:
+      - kupmios
 
   ogmios:
     container_name: ogmios
@@ -113,7 +151,7 @@ services:
       "--host", "0.0.0.0",
       "--port", "1337",
       "--node-socket", "/ipc/node.socket",
-      "--node-config", "/config/mainnet/config.json"
+      "--node-config", "/config/${NETWORK:-mainnet}/config.json"
     ]
     ports:
       - ${OGMIOS_PORT:-1337}:1337
@@ -124,6 +162,7 @@ services:
       retries: 15
       start_period: 60s
     profiles:
+      - kupmios
       - ogmios
 
   tx-submit-api:
@@ -226,6 +265,7 @@ volumes:
   bluefin-data:
     driver: local
   db-sync-data:
+  kupo-db:
   node-config:
   node-data:
   node-ipc:


### PR DESCRIPTION
Fixes #39 

```
{"severity":"Info","timestamp":"2024-08-25T22:42:31.358286253Z","thread":"18","message":{"Consumer":{"tag":"ConsumerRollForward","slotNo":308734,"inputs":40,"binaryData":0,"scripts":0}},"version":"v2.9.0+61ad7e"}
{"severity":"Info","timestamp":"2024-08-25T22:42:31.395340253Z","thread":"18","message":{"Consumer":{"tag":"ConsumerRollForward","slotNo":308788,"inputs":55,"binaryData":0,"scripts":0}},"version":"v2.9.0+61ad7e"}
```

```
CONTAINER ID   IMAGE                                     COMMAND                  CREATED              STATUS                        PORTS                                          NAMES
8b573360c552   cardanosolutions/kupo:v2.9.0              "/bin/kupo --node-so…"   About a minute ago   Up About a minute (healthy)   0.0.0.0:1442->1442/tcp                         kupo
19f186e6f42c   cardanosolutions/ogmios:v6.6.0            "/bin/ogmios --log-l…"   9 minutes ago        Up 8 minutes (healthy)        0.0.0.0:1337->1337/tcp                         ogmios
3e3679b97624   ghcr.io/blinklabs-io/cardano-node:9.1.0   "/usr/local/bin/entr…"   9 minutes ago        Up 9 minutes (healthy)        12788/tcp, 0.0.0.0:3001->3001/tcp, 12798/tcp   cardano-node
```