### PR TITLE
chore: bump node version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,8 @@
-version: "3.9"
-
+---
 services:
   cardano-node:
     container_name: cardano-node
-    image: ghcr.io/blinklabs-io/cardano-node:${CARDANO_NODE_VERSION:-10.1.3}
+    image: ghcr.io/blinklabs-io/cardano-node:${CARDANO_NODE_VERSION:-10.1.3-2}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:


### PR DESCRIPTION
Removed the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion