### PR TITLE
feat(cardano-wallet): add cardano-wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,11 @@ You can restart it by running the command below.
 ```bash
 docker compose --profile bluefin-inspector up -d --force-recreate
 ```
+
+### How to Use Cardano Wallet
+
+To start just the `cardano-wallet` service, which is part of the `wallet` profile, run:
+
+```bash
+docker compose --profile wallet up
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,6 +53,47 @@ services:
     profiles:
       - node-api
 
+  cardano-wallet:
+    container_name: cardano-wallet
+    image: ghcr.io/blinklabs-io/cardano-wallet:${CARDANO_WALLET_VERSION:-2024.11.18}
+    entrypoint: >
+      sh -c '
+      NETWORK=${NETWORK:-mainnet};
+      if [ "$NETWORK" = "mainnet" ]; then
+        echo "Using mainnet configuration";
+        exec cardano-wallet serve --port ${WALLET_PORT:-8090} \
+        --listen-address 0.0.0.0 \
+        --node-socket ${CARDANO_NODE_SOCKET_PATH:-/ipc/node.socket} \
+        --database ${WALLET_DB:-/data/wallet-db} \
+        --mainnet;
+      else
+        echo "Using testnet configuration: /config/$NETWORK/config.json";
+        exec cardano-wallet serve --port ${WALLET_PORT:-8090} \
+        --listen-address 0.0.0.0 \
+        --node-socket ${CARDANO_NODE_SOCKET_PATH:-/ipc/node.socket} \
+        --database ${WALLET_DB:-/data/wallet-db} \
+        --testnet /config/$NETWORK/byron-genesis.json;
+      fi'
+    environment:
+      - NETWORK=${NETWORK:-mainnet}
+      - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
+      - WALLET_DB=${WALLET_DB:-/data/wallet-db}
+      - WALLET_PORT=${WALLET_PORT:-8090}
+    volumes:
+      - wallet-data:/data
+      - node-ipc:/ipc
+      - node-config:/config
+    restart: on-failure
+    ports:
+      - "${WALLET_PORT:-8090}:8090"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
+    profiles:
+      - wallet
+
   bluefin:
     image: ghcr.io/blinklabs-io/bluefin:${BLUEFIN_VERSION:-0.13.1}
     container_name: bluefin
@@ -269,3 +310,4 @@ volumes:
   node-data:
   node-ipc:
   postgres:
+  wallet-data:


### PR DESCRIPTION
Closes #46 

Test with PREVIEW network:
```
docker ps
CONTAINER ID   IMAGE                                                COMMAND                  CREATED          STATUS                    PORTS                                                                         NAMES
7f7f834d5375   ghcr.io/blinklabs-io/cardano-wallet:2024.11.18       "sh -c ' NETWORK=pre…"   20 minutes ago   Up 20 minutes             0.0.0.0:8090->8090/tcp                                                        cardano-wallet
43d16617bc48   ghcr.io/blinklabs-io/cardano-node:10.1.3-2           "/usr/local/bin/entr…"   20 minutes ago   Up 20 minutes (healthy)   12788/tcp, 0.0.0.0:3001->3001/tcp, 12798/tcp                                  cardano-node
```

```
 curl http://localhost:8090/v2/network/information
{"network_info":{"network_id":"testnet","protocol_magic":2},"network_tip":{"absolute_slot_number":68572128,"epoch_number":793,"slot_number":56928,"time":"2024-12-26T15:48:48Z"},"next_epoch":{"epoch_number":794,"epoch_start_time":"2024-12-27T00:00:00Z"},"node_era":"conway","node_tip":{"absolute_slot_number":68572101,"epoch_number":793,"height":{"quantity":2808641,"unit":"block"},"slot_number":56901,"time":"2024-12-26T15:48:21Z"},"sync_progress":{"status":"ready"},"wallet_mode":"node"}%
```