### PR TITLE
fix(antithesis): debug logging and internal fix

### DIFF
--- a/antithesis/docker-compose.yaml
+++ b/antithesis/docker-compose.yaml
@@ -55,11 +55,13 @@ services:
       - "tracer-config.yaml"
 
   d1:
-    image: docker.io/wolf31o2/dingo:0.22.0_pre1-antithesis
+    image: docker.io/wolf31o2/dingo:0.22.0_pre2-antithesis
     init: true
     restart: always
     hostname: d1.example
     container_name: d1
+    command:
+      - "--debug"
     volumes:
       - p1-configs:/configs:ro
       - tracer:/tracer
@@ -197,4 +199,4 @@ networks:
   default:
     name: cardano-node-testnet
     driver: bridge
-    internal: ${INTERNAL_NETWORK:-true}
+    internal: ${INTERNAL_NETWORK}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables debug logging for the d1 service and fixes the network config to honor the INTERNAL_NETWORK env var. Also bumps the d1 image to docker.io/wolf31o2/dingo:0.22.0_pre2-antithesis.

<sup>Written for commit 8d443aa1fd1d8745ff6be2e905b3d15e09ca9b89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service image to a newer pre-release version.
  * Enabled debug mode for the service.
  * Adjusted network configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->